### PR TITLE
Multi-environment Support

### DIFF
--- a/src/Export-Entra.ps1
+++ b/src/Export-Entra.ps1
@@ -121,7 +121,7 @@ Function Export-Entra {
             else {
                 if ($hasParents){ $graphUri = $graphUri -replace '{id}', $Parents[$Parents.Count-1] }
                 try {
-                    $resultItems = Invoke-Graph $graphUri -Filter (Get-ObjectProperty $item 'Filter') -Select (Get-ObjectProperty $item 'Select') -QueryParameters (Get-ObjectProperty $item 'QueryParameters') -ApiVersion $apiVersion
+                    $resultItems = Invoke-Graph $graphUri -GraphBaseUri "$((Get-MgEnvironment -Name (Get-MgContext).Environment).GraphEndpoint)" -Filter (Get-ObjectProperty $item 'Filter') -Select (Get-ObjectProperty $item 'Select') -QueryParameters (Get-ObjectProperty $item 'QueryParameters') -ApiVersion $apiVersion
                 }
                 catch {
                     $e = ""

--- a/src/Get-EEAccessPackageAssignmentPolicies.ps1
+++ b/src/Get-EEAccessPackageAssignmentPolicies.ps1
@@ -17,5 +17,5 @@ Function Get-EEAccessPackageAssignmentPolicies  {
       [Parameter(Mandatory = $true)]
       [string[]]$Parents
   )
-  Invoke-Graph 'identityGovernance/entitlementManagement/accessPackageAssignmentPolicies' -Filter "(accessPackage/id eq '$($Parents[0])')"  -ApiVersion 'beta'
+  Invoke-Graph 'identityGovernance/entitlementManagement/accessPackageAssignmentPolicies' -GraphBaseUri "$((Get-MgEnvironment -Name (Get-MgContext).Environment).GraphEndpoint)" -Filter "(accessPackage/id eq '$($Parents[0])')"  -ApiVersion 'beta'
 }

--- a/src/Get-EEAccessPackageAssignments.ps1
+++ b/src/Get-EEAccessPackageAssignments.ps1
@@ -17,5 +17,5 @@ Function Get-EEAccessPackageAssignments {
       [Parameter(Mandatory = $true)]
       [string[]]$Parents
   )
-    Invoke-Graph 'identityGovernance/entitlementManagement/accessPackageAssignments' -Filter "(accessPackage/id eq '$($Parents[0])')"  -ApiVersion 'beta'
+    Invoke-Graph 'identityGovernance/entitlementManagement/accessPackageAssignments' -GraphBaseUri "$((Get-MgEnvironment -Name (Get-MgContext).Environment).GraphEndpoint)" -Filter "(accessPackage/id eq '$($Parents[0])')"  -ApiVersion 'beta'
 }

--- a/src/Get-EEAccessPackageResourceScopes.ps1
+++ b/src/Get-EEAccessPackageResourceScopes.ps1
@@ -17,5 +17,5 @@ Function Get-EEAccessPackageResourceScopes {
       [Parameter(Mandatory = $true)]
       [string[]]$Parents
   )
-    Invoke-Graph "identityGovernance/entitlementManagement/accessPackages/$($Parents[0])" -QueryParameters @{expand='accessPackageResourceRoleScopes(expand=accessPackageResourceRole,accessPackageResourceScope)'} -ApiVersion 'beta'
+    Invoke-Graph "identityGovernance/entitlementManagement/accessPackages/$($Parents[0])" -GraphBaseUri "$((Get-MgEnvironment -Name (Get-MgContext).Environment).GraphEndpoint)" -QueryParameters @{expand='accessPackageResourceRoleScopes(expand=accessPackageResourceRole,accessPackageResourceScope)'} -ApiVersion 'beta'
 }


### PR DESCRIPTION
# Corresponding Issue
[Multi-Cloud Support](https://github.com/microsoft/EntraExporter/issues/53)

## Overview 
- Adds the `-GraphBaseUri` parameter to all Invoke-Graph commands to allow for support of all cloud types, not just the Global (.com) endpoint.