### PR TITLE
Added missing Path parameter for teamwork schema

### DIFF
--- a/src/Get-EEDefaultSchema.ps1
+++ b/src/Get-EEDefaultSchema.ps1
@@ -856,6 +856,7 @@ function Get-EEDefaultSchema  {
         # Teams
         @{
             GraphUri = 'teamwork'
+            Path = 'Admin/Teams/settings.json'
             Filter = $null
             ApiVersion = 'beta'
             Tag = @('All', 'Config', 'Teams')


### PR DESCRIPTION
This fixes #70 that was introduced with #69. Feel free to adjust the path if something else would be more appropriate. For now, I aligned it with the path for the SharePoint output.

