### PR TITLE
Added application management policies to export

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Export-Entra -Path 'C:\EntraBackup\' -All -CloudUsersAndGroupsOnly
   * Permission Grant Policies
   * Token Issuance Policies
   * Token Lifetime Policies
+  * Application Management Policies
 * Identity Governance
   * Entitlement Management
     * Access Packages
@@ -144,6 +145,7 @@ Export-Entra -Path 'C:\EntraBackup\' -All -CloudUsersAndGroupsOnly
   * Feature Rollout Policies
   * Cross-tenant Access
   * Activity Based Timeout Policies
+  * Application Management Policies
 * Hybrid Authentication
   * Identity Providers
   * Home Realm Discovery Policies

--- a/src/Get-EEDefaultSchema.ps1
+++ b/src/Get-EEDefaultSchema.ps1
@@ -253,6 +253,22 @@ function Get-EEDefaultSchema  {
             ApplicationPermission = 'Policy.Read.All'
         },
         @{
+            GraphUri = 'policies/defaultAppManagementPolicy'
+            Path = 'Policies/DefaultAppManagementPolicy'
+            ApiVersion = 'beta'
+            Tag = @('All', 'Config', 'Policies')
+            DelegatedPermission = 'Policy.Read.All'
+            ApplicationPermission = 'Policy.Read.All'
+        },
+        @{
+            GraphUri = 'policies/appManagementPolicies'
+            Path = 'Policies/AppManagementPolicies'
+            ApiVersion = 'beta'
+            Tag = @('All', 'Config', 'Policies')
+            DelegatedPermission = 'Policy.Read.All'
+            ApplicationPermission = 'Policy.Read.All'
+        },
+        @{
             GraphUri = 'policies/authenticationMethodsPolicy/authenticationMethodConfigurations/email'
             Path = 'Policies/AuthenticationMethodsPolicy/AuthenticationMethodConfigurations/Email.json'
             Tag = @('All', 'Config', 'Policies')
@@ -752,6 +768,13 @@ function Get-EEDefaultSchema  {
                     Tag = @('All', 'Applications')
                     DelegatedPermission = 'Policy.Read.All'
                     ApplicationPermission = 'Policy.Read.All','Application.ReadWrite.All'
+                },
+                @{
+                    GraphUri = "applications/{id}/appManagementPolicies"
+                    Path = 'appManagementPolicies'
+                    Tag = @('All', 'Applications')
+                    DelegatedPermission = 'Policy.Read.All'
+                    ApplicationPermission = 'Policy.Read.All','Application.ReadWrite.All'
                 }
             )
         },
@@ -824,6 +847,13 @@ function Get-EEDefaultSchema  {
                 @{
                     GraphUri = 'servicePrincipals/{id}/tokenLifetimePolicies'
                     Path = 'tokenLifetimePolicies'
+                    Tag = @('All', 'ServicePrincipals')
+                    DelegatedPermission = 'Policy.Read.All'
+                    ApplicationPermission = 'Policy.Read.All','Application.ReadWrite.All'
+                },
+                @{
+                    GraphUri = 'servicePrincipals/{id}/appManagementPolicies'
+                    Path = 'appManagementPolicies'
                     Tag = @('All', 'ServicePrincipals')
                     DelegatedPermission = 'Policy.Read.All'
                     ApplicationPermission = 'Policy.Read.All','Application.ReadWrite.All'


### PR DESCRIPTION
This pull request adds exporting of application management policies. This includes the tenant default policy and any app management policies you have created.
It also exports what app management policy is applied to a application or serviceprincipal