### PR TITLE
Replace alias cmdlets with explicit cmdlets in IAM deduplication logic

### DIFF
--- a/src/command/Get-AzureResourceIAMData.ps1
+++ b/src/command/Get-AzureResourceIAMData.ps1
@@ -72,7 +72,7 @@ authorizationresources
     $kqlResult = Search-AzGraph2 -query $query
 
     # there can be duplicates with different createdOn/updatedOn, keep just the latest one
-    $kqlResult = $kqlResult | Group-Object -Property ($property | ? {$_ -notin "createdOn", "updatedOn"}) | % {if ($_.count -eq 1) {$_.group} else {$_.group | sort updatedOn | select -First 1}}
+    $kqlResult = $kqlResult | Group-Object -Property ($property | ? {$_ -notin "createdOn", "updatedOn"}) | % {if ($_.count -eq 1) {$_.group} else {$_.group | Sort-Object updatedOn | Select-Object -First 1}}
 
     if (!$kqlResult) { return }
     #endregion run the query


### PR DESCRIPTION
This change improves readability and consistency by replacing short alias usage with explicit PowerShell cmdlets in the IAM role assignment deduplication path.

What changed

Updated alias usage in the deduplication pipeline to full cmdlet names in [Get-AzureResourceIAMData.ps1:75]
Replaced sort with Sort-Object.
Replaced select with Select-Object.

Why

Explicit cmdlet names are easier to read and maintain.
Using full cmdlet names aligns with PowerShell style best practices and improves clarity for contributors.
Behavior impact

No intended functional change.
Logic and output remain the same; this is a readability/maintainability refactor.

Closes: #120 
