### PR TITLE
Document national/sovereign cloud usage in Connect-EntraExporter (#118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,37 @@ Connect-EntraExporter
 Export-Entra -Path 'C:\EntraBackup\'
 ```
 
+#### National and sovereign clouds
+
+By default the module connects to the commercial cloud (`Global`). To export from a national or sovereign cloud, pass the `-Environment` parameter, which is forwarded to `Connect-MgGraph`:
+
+```powershell
+# US Government (GCC High)
+Connect-EntraExporter -Environment USGov
+Export-Entra -Path 'C:\EntraBackup\'
+```
+
+The valid environment names and their Graph endpoints are provided by the installed Microsoft Graph PowerShell SDK, so they stay current with the SDK. List them with:
+
+```powershell
+Get-MgEnvironment | Select-Object Name, GraphEndpoint
+```
+
+Typical values include:
+
+| Name | Graph endpoint |
+| --- | --- |
+| Global | `https://graph.microsoft.com` |
+| USGov | `https://graph.microsoft.us` |
+| USGovDoD | `https://dod-graph.microsoft.us` |
+| China | `https://microsoftgraph.chinacloudapi.cn` |
+
+> [!NOTE]
+> Export types that rely on Azure Resource Manager (for example `IAM`, `PIMResources`) require `Connect-AzAccount` and are only available in clouds that have a matching Azure environment (`Global`, `USGov`, `USGovDoD`, `China`). In other clouds, select only Microsoft Graph based export types.
+
+> [!IMPORTANT]
+> Sovereign cloud environments (for example `BleuCloud`, `DelosCloud`, `GovSGCloud`) require a **custom application registration** — the default Microsoft Graph PowerShell application cannot be used in these environments. When registering your application, add a redirect URI of `ms-appx-web://Microsoft.AAD.BrokerPlugin/<YOUR_APP_CLIENT_ID>` to support WAM broker-based authentication, and use `Microsoft.Graph.Authentication` v2.36.1 or later. Refer to `Get-Help Connect-MgGraph -Full` and the [Microsoft Graph PowerShell SDK](https://github.com/microsoftgraph/msgraph-sdk-powershell) for the current guidance.
+
 While Connect-EntraExporter is available for convenience you can alternatively use Connect-MgGraph with the following scopes to authenticate.
 
 ```powershell

--- a/src/Connect-EntraExporter.ps1
+++ b/src/Connect-EntraExporter.ps1
@@ -6,12 +6,21 @@ $global:TenantID = $null
     Authenticate against Graph Api and/or Azure using delegated permissions (as user).
 
     To authenticate using a certificate or client secret, use Connect-MgGraph or Connect-AzAccount directly.
+.PARAMETER Environment
+    The national / sovereign cloud to connect to. Defaults to 'Global' (commercial cloud).
+
+    The value is passed to Connect-MgGraph (and translated to the matching Azure environment for Connect-AzAccount when an Az-based export type is selected). The list of valid names and their Graph endpoints is provided by the installed Microsoft Graph PowerShell SDK and can be listed with (Get-MgEnvironment).Name.
+
+    Sovereign cloud environments (for example BleuCloud, DelosCloud, GovSGCloud) require a custom application registration and Microsoft.Graph.Authentication v2.36.1 or later. See the "National and sovereign clouds" section of the README for details.
 .EXAMPLE
     PS C:\>Connect-EntraExporter
     Connect to home tenant of authenticated user.
 .EXAMPLE
     PS C:\>Connect-EntraExporter -TenantId 3043-343434-343434 -Type Users, Groups, Devices
     Connect to a specific Tenant. Correct delegated Graph scopes will be automatically requested based on the types specified.
+.EXAMPLE
+    PS C:\>Connect-EntraExporter -Environment USGov
+    Connect to a US Government (GCC High) tenant. Graph requests are directed to the USGov cloud (https://graph.microsoft.us) instead of the commercial cloud.
 #>
 function Connect-EntraExporter {
     param(
@@ -66,8 +75,8 @@ function Connect-EntraExporter {
             {$_ -in 'USGovDoD', 'USGov'} { $AzureEnvironment = 'AzureUSGovernment' }
             'Global'    { $AzureEnvironment = 'AzureCloud' }
             'China'     { $AzureEnvironment = 'AzureChinaCloud' }
-            'Germany'   { throw "'Germany' is deprecated environment." }
-            default     { throw "Unknown environment '$Environment'." }
+            'Germany'   { throw "'Germany' is a deprecated environment." }
+            default     { throw "The '$Environment' environment has no matching Azure Resource Manager (Az) environment, so export types that require Az authentication (e.g. IAM, PIMResources) are not available in this cloud. Re-run the export selecting only Microsoft Graph based types." }
         }
 
         Connect-AzAccount -Tenant $TenantId -Environment $AzureEnvironment


### PR DESCRIPTION
Addresses #118.

## Context

`Connect-EntraExporter` already forwards `-Environment` to `Connect-MgGraph`, and the valid names/endpoints come from the Microsoft Graph PowerShell SDK (`Get-MgEnvironment`) rather than a hardcoded list — so the Graph side stays current with the SDK. What was missing/outdated:

1. The `-Environment` parameter was **undocumented** (no comment-based help, no README mention).
2. The Graph-to-Azure environment translation `switch` threw a misleading **`Unknown environment '<name>'`** for any environment without an Azure Resource Manager equivalent (including newer sovereign clouds) when an Az-based export type was selected.
3. No documentation of the **custom application registration** requirement the SDK now imposes for sovereign clouds.

## Changes

- **`src/Connect-EntraExporter.ps1`**
  - Add comment-based help for `-Environment` and a `-Environment USGov` example.
  - Replace the `Unknown environment` throw with an actionable message: the selected cloud has no matching Az environment, so Az-based export types (`IAM`, `PIMResources`, ...) aren't available there — re-run with only Microsoft Graph based types. The known mappings (USGov/USGovDoD → AzureUSGovernment, Global → AzureCloud, China → AzureChinaCloud) are unchanged.
- **`README.md`** — new "National and sovereign clouds" subsection:
  - Using `-Environment` (with a USGov example).
  - Listing valid environments/endpoints via `Get-MgEnvironment` (so the doc doesn't go stale).
  - The Az-based-export-types caveat.
  - The custom app registration + `ms-appx-web://Microsoft.AAD.BrokerPlugin/<YOUR_APP_CLIENT_ID>` WAM redirect URI + `Microsoft.Graph.Authentication` v2.36.1+ requirement for sovereign clouds, as noted in #118.

I intentionally did **not** hardcode Azure environment names for the newer partner sovereign clouds (BleuCloud/DelosCloud/GovSGCloud) or force-bump the module's minimum `Microsoft.Graph.Authentication` dependency, since the v2.36.1 requirement is specific to sovereign clouds and shouldn't be imposed on commercial-cloud users. Happy to adjust if you'd prefer either.

## Verification

- `Parser.ParseFile` — no syntax errors.
- `PSScriptAnalyzer` — no new findings (only pre-existing repo-wide warnings remain).
- Verified the `switch` still maps USGov/USGovDoD/Global/China correctly and throws the new actionable message for an unmapped cloud.

## Related

The actual GCC-High export failure in #117 (batch requests hitting the commercial endpoint) is fixed separately in #122 — that's the change that makes national-cloud exports actually run. This PR complements it by documenting connection and clarifying the Az-type limitation.